### PR TITLE
Convert to Windows path if using cygwin git

### DIFF
--- a/nuget/build/SemanticGit.props
+++ b/nuget/build/SemanticGit.props
@@ -85,6 +85,19 @@
 		<GitExe>git</GitExe>
 	</PropertyGroup>
 
+	<!--
+	============================================================
+              CygPathExe Property
+	
+	If we are using cygwin git, we need to pipe the path to
+	cygpath to convert it into a Windows path. If the path is
+	already a Windows path, it will be returned unchanged.
+	============================================================
+	-->
+	<PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+		<CygPathExe Condition="'$(CygPathExe)' == '' And Exists('C:\cygwin\bin\cygpath.exe')">C:\cygwin\bin\cygpath.exe</CygPathExe>
+	</PropertyGroup>
+
 	<PropertyGroup>
 		<SemanticPropsImported>true</SemanticPropsImported>
 	</PropertyGroup>

--- a/nuget/build/SemanticGit.targets
+++ b/nuget/build/SemanticGit.targets
@@ -195,6 +195,10 @@ End Class
 			<Output TaskParameter="Output" PropertyName="_GitRoot" />
 		</Run>
 
+		<Run Exe="$(CygPathExe)" Args="-w $(_GitRoot)" WorkingDir="$(MSBuildProjectDirectory)" Condition="'$(CygPathExe)' != ''">
+			<Output TaskParameter="Output" PropertyName="_GitRoot" />
+		</Run>
+
 		<PropertyGroup>
 			<GitRoot>$([System.IO.Path]::GetFullPath($(_GitRoot)))</GitRoot>
 		</PropertyGroup>


### PR DESCRIPTION
The git root path is obtained by `git rev-parse --show-toplevel`
On my cygwin setup, the returned path is something like "/home/Alex/repo"
and when Path.GetFullPath is called, this becomes "C:\home\Alex\repo"
However, the real path is "C:\cygwin\home\Alex\repo"

This patch calls cygpath if it exists to get the correct path.
If the path is already a Windows path, then cygpath will return it
unchanged.